### PR TITLE
feat: add SetLogger for runtime logger replacement

### DIFF
--- a/logx.go
+++ b/logx.go
@@ -154,10 +154,17 @@ func As() *zerolog.Logger {
 // SetLogger replaces the global logger with a custom-built zerolog.Logger.
 // Use this when you need to swap the logger at runtime (e.g., to suppress
 // console output for a TUI or attach custom hooks). Safe to call concurrently.
+//
+// Note: This only swaps the logger instance. It does not update process-wide
+// zerolog settings (zerolog.SetGlobalLevel, ErrorStackMarshaler) — use
+// Initialize for that. Loggers previously obtained via As() are shallow copies
+// and will continue writing to the old destination; callers should re-fetch
+// via As() after SetLogger to use the new logger.
 func SetLogger(l zerolog.Logger) {
 	loggerMux.Lock()
+	defer loggerMux.Unlock()
+
 	logger = l
-	loggerMux.Unlock()
 }
 
 func StartTimer() {

--- a/logx.go
+++ b/logx.go
@@ -151,6 +151,15 @@ func As() *zerolog.Logger {
 	return &loggerCopy // Return pointer to the copy, not to the shared global
 }
 
+// SetLogger replaces the global logger with a custom-built zerolog.Logger.
+// Use this when you need to swap the logger at runtime (e.g., to suppress
+// console output for a TUI or attach custom hooks). Safe to call concurrently.
+func SetLogger(l zerolog.Logger) {
+	loggerMux.Lock()
+	logger = l
+	loggerMux.Unlock()
+}
+
 func StartTimer() {
 	startTime = time.Now()
 }

--- a/logx_test.go
+++ b/logx_test.go
@@ -1,10 +1,12 @@
 package logx
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,6 +52,21 @@ func TestExecutionTime(t *testing.T) {
 func TestGetPid(t *testing.T) {
 	pid := GetPid()
 	assert.Equal(t, os.Getpid(), pid)
+}
+
+func TestSetLogger(t *testing.T) {
+	var buf bytes.Buffer
+	custom := zerolog.New(&buf).With().Str("custom", "true").Logger()
+
+	prev := *As()
+	SetLogger(custom)
+	t.Cleanup(func() {
+		SetLogger(prev)
+	})
+
+	As().Info().Msg("hello")
+	assert.Contains(t, buf.String(), "hello")
+	assert.Contains(t, buf.String(), `"custom":"true"`)
 }
 
 // TestAs_ReturnsPointerToCopy verifies that As() returns a pointer and that


### PR DESCRIPTION
## Description

Add SetLogger(zerolog.Logger) to allow callers to replace the global logger with a custom-built instance at runtime. This is needed when Initialize is insufficient — e.g., to suppress console output for a TUI or to attach custom hooks. Protected by the existing RWMutex.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `go.mod` and/or `go.sum` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit
  message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a
   breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any
   type. NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
